### PR TITLE
Disable building a Latex document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra dvipng pandoc
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 dvipng pandoc
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Sphinx
           command: |
             cd docs/
-            make html SPHINXOPTS="-W"
+            make html
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,47 +57,6 @@ html_theme = 'pydata_sphinx_theme'
 # html_static_path = ['_static']
 
 
-# -- Options for LaTeX output ------------------------------------------
-
-# latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-# }
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass
-# [howto, manual, or own class]).
-# latex_documents = [
-#     (master_doc, 'pyfar.tex',
-#      u'pyfar Gallery',
-#      u'The pyfar developers', 'manual'),
-# ]
-
-
-# -- Options for manual page output ------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-# man_pages = [
-#     (master_doc, 'pyfar',
-#      u'pyfar Gallery',
-#      [author], 1)
-# ]
-
-
 # -- Options for Texinfo output ----------------------------------------
 
 # Grouping the document tree into Texinfo files. List of tuples

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ html_theme = 'pydata_sphinx_theme'
 
 # -- Options for LaTeX output ------------------------------------------
 
-latex_elements = {
+# latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
@@ -75,27 +75,27 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-}
+# }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'pyfar.tex',
-     u'pyfar Gallery',
-     u'The pyfar developers', 'manual'),
-]
+# latex_documents = [
+#     (master_doc, 'pyfar.tex',
+#      u'pyfar Gallery',
+#      u'The pyfar developers', 'manual'),
+# ]
 
 
 # -- Options for manual page output ------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'pyfar',
-     u'pyfar Gallery',
-     [author], 1)
-]
+# man_pages = [
+#     (master_doc, 'pyfar',
+#      u'pyfar Gallery',
+#      [author], 1)
+# ]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -103,14 +103,14 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'pyfar',
-     u'pyfar Gallery',
-     author,
-     'pyfar',
-     'One line description of project.',
-     'Miscellaneous'),
-]
+# texinfo_documents = [
+#     (master_doc, 'pyfar',
+#      u'pyfar Gallery',
+#      author,
+#      'pyfar',
+#      'One line description of project.',
+#      'Miscellaneous'),
+# ]
 
 # -- Options for nbsphinx -------------------------------------------------
 nbsphinx_prolog = r"""


### PR DESCRIPTION
Requires installing texlive via apt, which is quite time consuming. 
Having a latex document of the gallery does not really seem worthwhile doing anyways.