### PR TITLE
Fix pytest versions to <8.1.0 due to lacking support in nbmake

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8
 coverage
 Sphinx>=4.0
 twine
-pytest
+pytest<8.1.0
 pytest-runner
 pytest-cov
 numpy>=1.23.0


### PR DESCRIPTION
Workaround for #26 until https://github.com/treebeardtech/nbmake/issues/119 is resolved.

Related #24 