### PR TITLE
Remove duplicate include of gallery

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,17 +179,6 @@ educational and commercial use.
 
 |
 
-Pyfar gallery
-=============
-
-This is the pyfar gallery. It provides a collection of examples and tutorials
-for the whole pyfar ecosystem.
-
-.. include:: examples_gallery.rst
-   :start-after: .. include_label
-
-|
-
 Contribute
 ===========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,25 @@ educational and commercial use.
       :text-align: center
       :shadow: lg
 
+      **Example gallery**
+      ^^^^
+      The pyfar gallery contains notebooks explaining fundamental concepts and showing application examples.
+      +++
+      .. grid:: 1
+
+         .. grid-item::
+
+            .. button-link:: examples_gallery.html
+               :color: primary
+               :expand:
+               :shadow:
+
+               gallery
+
+   .. grid-item-card::
+      :text-align: center
+      :shadow: lg
+
       **coming next...**
       ^^^^
       The pyfar base package will be extended. New packages for audio


### PR DESCRIPTION
The gallery is included on the first page, leading to an error in the tests, because corresponding identifiers exist twice.

I removed the include from the first page and instead added a card. Open for suggestions on the text and the name of the button on the card.