### PR TITLE
remove external link symbol in header

### DIFF
--- a/docs/_templates/navbar-nav.html
+++ b/docs/_templates/navbar-nav.html
@@ -10,30 +10,30 @@
 
                         <li class="nav-item">
                           <a class="nav-link nav-internal" href="examples_gallery.html">
-                            Examples gallery
+                            Examples
                           </a>
                         </li>
-                        
+
                         <li class="nav-item">
-                          <a class="nav-link nav-external" href="https://pyfar.readthedocs.io/en/stable/">
+                          <a class="nav-link" href="https://pyfar.readthedocs.io/en/stable/">
                             pyfar
                           </a>
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link nav-external" href="https://sofar.readthedocs.io/en/stable/">
+                          <a class="nav-link" href="https://sofar.readthedocs.io/en/stable/">
                             sofar
                           </a>
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link nav-external" href="https://spharpy.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://spharpy.readthedocs.io/en/latest/">
                             spharpy
                           </a>
                         </li>
-                        
+
                         <li class="nav-item">
-                          <a class="nav-link nav-external" href="https://pyrato.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://pyrato.readthedocs.io/en/latest/">
                             pyrato
                           </a>
                         </li>


### PR DESCRIPTION
- remove external link symbol in header
- rename ``Examples gallery`` to ``Examples``