### PR TITLE
Restrict numpy version

### DIFF
--- a/docs/gallery/interactive/fast_fourier_transform.ipynb
+++ b/docs/gallery/interactive/fast_fourier_transform.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "fir = pf.dsp.filter.fractional_octave_bands(\n",
-    "    impulse, num_fractions=1, freq_range=(500, 700))"
+    "    impulse, num_fractions=1, frequency_range=(500, 700))"
    ]
   },
   {

--- a/docs/gallery/interactive/pyfar_filter_types.ipynb
+++ b/docs/gallery/interactive/pyfar_filter_types.ipynb
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y = pf.dsp.filter.fractional_octave_bands(impulse, 1, freq_range=(60, 12e3))\n",
+    "y = pf.dsp.filter.fractional_octave_bands(impulse, 1, frequency_range=(60, 12e3))\n",
     "ax = pf.plot.freq(y)\n",
     "ax.set_ylim(-60, 5);"
    ]

--- a/docs/gallery/interactive/pyfar_filtering.ipynb
+++ b/docs/gallery/interactive/pyfar_filtering.ipynb
@@ -141,7 +141,7 @@
    "outputs": [],
    "source": [
     "# Create the filter bank\n",
-    "Gammatones = pf.dsp.filter.GammatoneBands(freq_range=[20, 20_000])\n",
+    "Gammatones = pf.dsp.filter.GammatoneBands(frequency_range=[20, 20_000])\n",
     "\n",
     "# Apply the filter bank to an impulse with a duration of 4096 samples\n",
     "impulse_filter_bank, _ = Gammatones.process(pf.signals.impulse(4096))\n",

--- a/docs/gallery/interactive/pyfar_introduction.ipynb
+++ b/docs/gallery/interactive/pyfar_introduction.ipynb
@@ -163,7 +163,7 @@
     "\n",
     "To do this, you need to use an interactive matplotlib backend. For jupyter notebooks one can for example use the matplotlib magic `%matplotlib ipympl`, which has been executed at the top of the notebook already.\n",
     "\n",
-    "A list of available shortcuts is found in the [documentation](https://pyfar.readthedocs.io/en/stable/concepts/pyfar.plot.html#interactive-plots) or by executing the following function.\n"
+    "A list of available shortcuts is found in the [documentation](https://pyfar.readthedocs.io/en/stable/modules/pyfar.plot.html#pyfar.plot.shortcuts) or by executing the following function.\n"
    ]
   },
   {
@@ -490,7 +490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `pyfar.Coordinates` class is designed for storing, manipulating, and accessing coordinate points. It supports a large variety of different coordinate conventions and the conversion between them. Visit the [coordinate concepts](https://pyfar.readthedocs.io/en/stable/concepts/pyfar.coordinates.html) for a graphical overview of available coordinate systems. Let's extract the azimuth angle in degree."
+    "The `pyfar.Coordinates` class is designed for storing, manipulating, and accessing coordinate points. It supports a large variety of different coordinate conventions and the conversion between them. Visit the [coordinate documentation](https://pyfar.readthedocs.io/en/stable/classes/pyfar.coordinates.html) for a graphical overview of available coordinate systems. Let's extract the azimuth angle in degree."
    ]
   },
   {

--- a/docs/gallery/interactive/pyfar_orientations.ipynb
+++ b/docs/gallery/interactive/pyfar_orientations.ipynb
@@ -150,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   },
   "vscode": {
    "interpreter": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ twine
 pytest<8.1.0
 pytest-runner
 pytest-cov
-numpy>=1.23.0
+numpy>=1.23.0,<2
 scipy>=1.5.0
 matplotlib<=3.7
 urllib3


### PR DESCRIPTION
building the docs is failing because of an error coming from Matplotlib. Sphinx suggests: 'If you are a user of the module, the easiest solution will be to downgrade to 'numpy<2' or try to upgrade the affected module. We expect that some modules will need time to support NumPy 2.', which I did.

closes #68, still requires #69 

