### PR TITLE
Fixed missing link in pyfar_audio_objects.ipynb

### DIFF
--- a/docs/gallery/interactive/pyfar_audio_objects.ipynb
+++ b/docs/gallery/interactive/pyfar_audio_objects.ipynb
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is also **important to note** that the data returned by the `freq` property can depend on the normalization of the Discrete Fourier Transform as explained in more detail `here`. The frequency data without normalization can be accessed using the `freq_raw` property. However, for this example the two return the same results"
+    "It is also **important to note** that the data returned by the `freq` property can depend on the normalization of the Discrete Fourier Transform as explained in more detail [here](https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/fast_fourier_transform.html). The frequency data without normalization can be accessed using the `freq_raw` property. However, for this example the two return the same results"
    ]
   },
   {


### PR DESCRIPTION
I guess the `here` was meant to linkt to another page, where the normalizations are explained. As these are explained in the examples FFT page, I added the link to that page. 