### PR TITLE
Update requirements for compatibility with recent pyfar and Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pip
-bump2version
+bump-my-version
 wheel
 watchdog
 flake8
@@ -9,9 +8,9 @@ twine
 pytest<8.1.0
 pytest-runner
 pytest-cov
-numpy>=1.23.0,<2
+numpy>=1.23.0
 scipy>=1.5.0
-matplotlib<=3.7
+matplotlib
 urllib3
 deepdiff
 pydata-sphinx-theme


### PR DESCRIPTION
Adjust the `requirements.txt` file to improve compatibility with the latest versions of Python and pyfar.
The matplotlib constraint is no longer required by recent pyfar versions, and starts to cause issues with new Python versions. 

Resolves #89 and #71.
Also related to #82, where the requirements weren't updated.