### PR TITLE
make package dropdown in header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,8 @@ html_theme_options = {
     "navbar_start": ["navbar-logo"],
     "navbar_end": ["navbar-icon-links", "theme-switcher"],
     "navbar_align": "content",
-    "header_links_before_dropdown": 8,
+    "header_links_before_dropdown": 5,  # manual set
+    "header_dropdown_text": "Packages",  # Change dropdown name from "More" to "Packages"
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
Problem: 
header in our documantion becomes to long and it not uniform along all packages

Solution:
This PR will lead to the same header file but automatic as in the pyfar pr
see for an example:
https://pyfar--789.org.readthedocs.build/en/789/pyfar.html


apply to other packegaes
- [x] pyfar https://github.com/pyfar/pyfar/pull/789
- [x] sofar https://github.com/pyfar/sofar/pull/125
- [x] spharpy https://github.com/pyfar/spharpy/pull/110
- [ ] pyrato https://github.com/pyfar/pyrato/pull/48

packages under development:
- [x] imkar https://github.com/pyfar/imkar/pull/29
- [ ] haiopy
