### PR TITLE
fix links to oer courses

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -197,7 +197,7 @@ for the whole pyfar ecosystem.
    :gutter: 4
 
    .. grid-item-card::
-      :link: examples_gallery.html#getting_started
+      :link: examples_gallery.html#getting-started
       :text-align: center
 
       Getting Started


### PR DESCRIPTION
closes #127 

Fix links to oer courses on main page.
Apparently sphinx converts underscores (_) in section labels to hyphens (-) when rendering html.

So addressing 

```
.. nbgallery::
   :name: some_course
```

works using

...open_educational_resources.html#**some-course**

