### PR TITLE
hot: pyrato intro fix wrong usage of plot

### DIFF
--- a/docs/gallery/interactive/pyrato_introduction.ipynb
+++ b/docs/gallery/interactive/pyrato_introduction.ipynb
@@ -196,8 +196,8 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "pf.plot.time(edc_lundeby, unit='s', dB=True)\n",
-    "plt.title(f\"Energy Decay Curve\")\n",
+    "pf.plot.time(edc_lundeby, unit='s', dB=True, log_prefix=10)\n",
+    "plt.title(\"Energy Decay Curve\")\n",
     "plt.show()"
    ]
   },
@@ -404,7 +404,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env",
+   "display_name": "gallery",
    "language": "python",
    "name": "python3"
   },
@@ -418,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I found a missing log_prefix for the etc plot and fixed it.