### PR TITLE
SH-Notebook - Fix formatting of \isin

### DIFF
--- a/docs/gallery/interactive/spherical_harmonic_hrtf_interpolation.ipynb
+++ b/docs/gallery/interactive/spherical_harmonic_hrtf_interpolation.ipynb
@@ -192,7 +192,7 @@
     "\n",
     "where order $n$ and degree $m$ up to the maximum spherical harmonic order $N$.\n",
     "\n",
-    "In the above $\\mathbf{Y} \\isin \\mathbb{R}^{Q \\times (N+1)^2}$ denotes the matrix\n",
+    "In the above $\\mathbf{Y} \\in \\mathbb{R}^{Q \\times (N+1)^2}$ denotes the matrix\n",
     "\n",
     "$$\n",
     "\\mathbf{Y} = \\begin{bmatrix}\n",


### PR DESCRIPTION
`\isin` isn't displayed correctly since it is part of a specific latex extension that isn't available by default. 
Changed it to `\in`