### PR TITLE
allow for all pytest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flake8
 coverage
 Sphinx
 twine
-pytest<8.1.0
+pytest
 pytest-runner
 pytest-cov
 numpy>=1.23.0


### PR DESCRIPTION
for some reason pytest version was restricted to a certain version. History tells this was done due to nbmake. According to nbmake this is not required atm, so I removed it.