### PR TITLE
DOC: Add  governance document draft 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx_design",
     "sphinx_favicon",
     "sphinx_copybutton",
+    'sphinx_mdinclude',
 ]
 
 templates_path = ['_templates']

--- a/docs/contribute/general/governance.md
+++ b/docs/contribute/general/governance.md
@@ -1,0 +1,71 @@
+# Governance
+
+## Steering Council
+
+The Steering Council is the governance body of the pyfar project. It is composed of people who are already actively involved in the development of pyfar packages and who have a broad understanding of all packages and the relationships between them. The overall role of the Council is to ensure, with input from the Community, the long-term well-being of the project, both technically and as a community.
+
+During the everyday project activities, council members participate in all discussions, code review and other project activities as peers with all other Contributors and the Community. In these everyday activities, Council Members do not have any special power or privilege through their membership on the Council. However, it is expected that because of the quality and quantity of their contributions and their expert knowledge of the Project Software and Services that Council Members will provide useful guidance, both technical and in terms of project direction, to potentially less experienced contributors.
+
+### Responsibilities
+
+The Steering Council is responsible for:
+
+- **Setting the overall scope and long-term vision** and roadmap of the pyfar ecosystem
+- Accepting or rejecting **Enhancement Proposals (DEPs)** that have project-wide or cross-package implications
+- **Governance decisions** — changing rules, roles, processes, or the Code of Conduct
+- **Representing the project** externally (e.g., to academic partners and funding bodies)
+- **Resolving conflicts** that cannot be settled among Maintainers through discussion or informal voting
+- Accepting new maintainers into the project and ensuring that a sufficient number of maintainers are available per project
+
+The Steering Council does not replace Maintainers on daily technical decisions within a single package. Routine pull request merges, deprecations with clear migration paths, and package-level technical direction remain within the authority of each package's Maintainers.
+
+### What Reaches the Steering Council
+
+In practice, most decisions in the pyfar project will be resolved by Maintainers via lazy consensus or informal vote.
+**The committee is involved when:**
+
+- A DEP has **cross-package or project-wide impact** — for example, introducing a new shared data structure, changing a convention adopted by all packages, or deprecating functionality that other packages depend on
+- A DEP proposes a **large new feature or new package** — meaning functionality that significantly expands a package or the project, requires substantial development effort, or has broad implications for the user-facing API
+- A question of **removing or significantly altering** long-standing functionality that many users rely on
+- A DEP proposes a **governance change** — modifying roles, voting rules, the DEP process, or the Code of Conduct
+- Maintainers across packages **cannot reach consensus** after discussion
+- A decision has legal, financial, or external relations implications
+
+### Composition
+
+- **Size:** A minimum of **4** and a maximum of **5** members. Keeping the committee small ensures it remains functional and decisive. At least 4 members are required to participate in a vote.
+- **Eligibility:** Any person with at least **1 - 2 years of active pyfar contribution** — meaning regular commits, reviews, infrastructure work, community building and support, or active participation in weekly meetings — and who expresses willingness to remain in the role for **at least one year**.
+- **Overlap with Maintainers:** Steering Council members will in most cases also hold a Maintainer role in one or more packages. The committee is a subset of the most experienced and engaged contributors, not a separate group.
+
+#### Council Chair
+
+The council appoints a council chair. The chair's responsibilities are
+
+- Organizing and preparing Steering Council meetings
+- Ensuring the composition of the Steering Council stays current
+
+### Selection Process
+
+1. Nomination are accepted via self-nomination and peer nomination.
+2. All current **actively involved Maintainers/Developers across all packages** are eligible to vote — not only the existing committee members.
+3. Informal voting proceeds by simple majority; in case of a tie, a second round is held
+4. Candidates may vote for themselves; this is considered a legitimate expression of willingness to serve
+5. Elected members are announced to the full pyfar community
+
+### Stepping Down & Emeritus Status
+
+Members who step down from the Steering Council are recognized with **emeritus status**, acknowledging their past contributions. Emeritus members may attend meetings and contribute to discussions but do not hold voting rights.
+
+### Expected Conduct
+
+Steering Council members are expected to participate in votes, particularly on major DEPs and governance decisions. If a member becomes inactive in the project for a period of 6 months, they will be considered for removal from the Council. Before removal, inactive Member will be approached to see if they plan on returning to active participation. If not, they will be removed immediately upon a Council vote.
+Sustained absence from votes without notice may prompt a discussion about whether a member wishes to continue in the role.
+
+### Conflict of interest
+
+It is expected that the Council Members will be employed at a wide range of companies, universities and non-profit organizations. Because of this, it is possible that Members will have conflict of interests. Such conflict of interests include, but are not limited to:
+
+- Financial interests, such as investments, employment or contracting work, outside of The Project that may influence their work on The Project.
+- Access to proprietary information of their employer that could potentially leak into their work with the Project.
+
+All members of the Council shall disclose to the rest of the Council any conflict of interest they may have. Members with a conflict of interest in a particular issue may participate in Council discussions on that issue, but must recuse themselves from voting on the issue.

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -84,6 +84,7 @@ community for the acoustics research community. We welcome any contributions
    Reporting Issues <general/reporting_issues>
    Development Guidelines <general/pr_workflow>
    Reviewer Guidelines <general/reviewing>
+   Governance <general/governance>
 
 .. toctree::
    :maxdepth: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ watermark
 pytz
 sphinx-copybutton
 pooch
+sphinx_mdinclude


### PR DESCRIPTION
### Proposed Changes

- Add draft for the governance document



**This draft was used as basis for the establishment of pyfar's first steering council.**

Note: The use of markdown is only temporary and will be changed before the PR is finalized.